### PR TITLE
feat(cacher): tartanair intergration.

### DIFF
--- a/CacherDataset.py
+++ b/CacherDataset.py
@@ -115,4 +115,3 @@ if __name__=="__main__":
         disp = cv2.hconcat((ss, depthvis, flowvis))
         cv2.imshow('img', disp)
         cv2.waitKey(0)
-    import ipdb;ipdb.set_trace()

--- a/ConfigParser.py
+++ b/ConfigParser.py
@@ -19,6 +19,7 @@ class ConfigParser(object):
                                   ]
 
         self.cacher_paramlist = [   'data_root_key',
+                                    'data_root_path_override', # override the default data root path with this one.
                                     'subset_framenum', # frame number in cacher
                                     'worker_num', # how many works for the cacher
                                     'load_traj' # load one trajectory into the cacher at one time
@@ -30,6 +31,9 @@ class ConfigParser(object):
 
     def parse_from_fp(self, fp):
         x = yaml.safe_load(open(fp, 'r'))
+        return self.parse(x)
+
+    def parse_from_dict(self, x):
         return self.parse(x)
 
     def parse_sub_global_param(self, spec, param_name, paramlist):

--- a/DataCacher.py
+++ b/DataCacher.py
@@ -12,7 +12,7 @@ from .CacherDataset import CacherDataset, SimpleDataloader
 
 class DataCacher(object):
 
-    def __init__(self, modality_dict, data_splitter, data_root, num_worker, batch_size=1, load_traj=False):
+    def __init__(self, modality_dict, data_splitter, data_root, num_worker, batch_size=1, load_traj=False, verbose=False):
         '''
         modality_dict: {mod_name: modality, ..} 
                         mod_name: the key of the sample dict, e.g. img0
@@ -23,6 +23,8 @@ class DataCacher(object):
         The sizes defined in the modalities_sizes are are the sizes required for training, 
         if the loaded data is in different shape with what defined in modalities_sizes, the data will be resized
         '''
+        self.verbose = verbose
+
         # self.modalities_sizes = modalities_sizes
         # self.datatypes = list(self.modalities_sizes.keys())
         self.modality_dict = modality_dict
@@ -51,8 +53,8 @@ class DataCacher(object):
         self.mod_ind = 0
         self.dataiter = None
         # This following lines won't allocate RAM memory yet
-        self.buffer_a = TrajBuffer(self.modnames, self.modalities)
-        self.buffer_b = TrajBuffer(self.modnames, self.modalities)
+        self.buffer_a = TrajBuffer(self.modnames, self.modalities, verbose)
+        self.buffer_b = TrajBuffer(self.modnames, self.modalities, verbose)
 
         # initialize a dataloader
         self.stop_flag = False
@@ -75,8 +77,7 @@ class DataCacher(object):
             startind += datanp.shape[0]
         assert startind == self.loading_buffer.framenum * modality.freq_mult, \
             "Load simple mod {} for {} frames, which does not match {}".format(modname, startind, self.loading_buffer.framelist * modality.freq_mult)
-        print('  type {} loaded: traj {} frames {}'.format(self.active_modname, 
-                                len(self.loading_buffer.trajlist), startind))
+        self.vprint('  type {} loaded: traj {} frames {}'.format(self.active_modname, len(self.loading_buffer.trajlist), startind))
         self.loading_buffer.set_full(self.active_modname)
 
     def set_load_mod(self, k): 
@@ -145,7 +146,7 @@ class DataCacher(object):
             if self.active_mod+1 == self.modnum: # all modalities have been loaded
                 assert self.loading_buffer.is_full, "Datacacher: the buffer is not full"
                 self.new_buffer_available = True
-                print('Buffer loaded: traj {}, frame {}, time {}'.format(len(self.loading_buffer.trajlist),len(self.loading_buffer), time.time()-self.starttime))
+                self.vprint('Buffer loaded: traj {}, frame {}, time {}'.format(len(self.loading_buffer.trajlist),len(self.loading_buffer), time.time()-self.starttime))
                 break
             else: # load the next modality
                 if self.set_load_mod(self.active_mod + 1):
@@ -161,7 +162,7 @@ class DataCacher(object):
                     self.loading_buffer.insert_frame_one_mod(self.modind, self.active_modname, datanp)
                     self.modind += self.batch_size
                 except StopIteration:
-                    print('  type {} loaded: traj {}, frame {}, time {}'.format(self.active_modname, len(self.loading_buffer.trajlist),len(self.loading_buffer), time.time()-self.starttime))
+                    self.vprint('  type {} loaded: traj {}, frame {}, time {}'.format(self.active_modname, len(self.loading_buffer.trajlist),len(self.loading_buffer), time.time()-self.starttime))
                     self.loading_buffer.set_full(self.active_modname)
                     self.update_mod()
             else:
@@ -169,6 +170,10 @@ class DataCacher(object):
 
     def stop_cache(self):
         self.stop_flag = True
+    
+    def vprint(self, *args, **kwargs):
+        if self.verbose:
+            print(*args, **kwargs)
 
 # python -m Datacacher.DataCacher
 if __name__=="__main__":

--- a/DataCacher.py
+++ b/DataCacher.py
@@ -156,7 +156,7 @@ class DataCacher(object):
         while not self.stop_flag: # this loops forever unless the stop flag is set
             if not self.new_buffer_available:
                 try:
-                    sample = self.dataiter.next()
+                    sample = next(self.dataiter)
                     datanp = sample.numpy()
                     self.loading_buffer.insert_frame_one_mod(self.modind, self.active_modname, datanp)
                     self.modind += self.batch_size

--- a/MultiDatasets.py
+++ b/MultiDatasets.py
@@ -113,11 +113,11 @@ class MultiDatasets(object):
 
         # load sample from the dataloader
         try:
-            sample = self.dataiters[datasetInd].next()
+            sample = next(self.dataiters[datasetInd])
             if sample[list(sample.keys())[0]].shape[0] < self.batch and (fullbatch is True): # the imcomplete batch is thrown away
                 # self.dataiters[datasetInd] = iter(self.dataloaders[datasetInd])
                 # sample = self.dataiters[datasetInd].next()
-                sample = self.dataiters[datasetInd].next()
+                sample = next(self.dataiters[datasetInd])
         except StopIteration:
             # import ipdb;ipdb.set_trace()
             if notrepeat: # wait for the new buffer ready, do not repeat the current buffer
@@ -134,7 +134,7 @@ class MultiDatasets(object):
                 self.dataloaders[datasetInd] = DataLoader(self.datasets[datasetInd], batch_size=self.batch, shuffle=self.shuffle, num_workers=self.workernum)
                 self.subsetrepeat[datasetInd] = -1
             self.dataiters[datasetInd] = iter(self.dataloaders[datasetInd])
-            sample = self.dataiters[datasetInd].next()
+            sample = next(self.dataiters[datasetInd])
             new_buffer = True
             self.subsetrepeat[datasetInd] += 1
             print('==> Working on {} for the {} time'.format(self.datafiles[datasetInd], self.subsetrepeat[datasetInd]))

--- a/RAMBuffer.py
+++ b/RAMBuffer.py
@@ -16,7 +16,7 @@ def convert_type(nptype):
  
 class RAMBufferBase(object):
     # the buffer to store the sequential data
-    def __init__(self, datatype):
+    def __init__(self, datatype, verbose=False):
         '''
         datatype: np datatype
         datasize: a tuple
@@ -28,6 +28,11 @@ class RAMBufferBase(object):
         self.datatype = datatype
         self.datasize = (0)
         # self.reset(datasize)
+        self.verbose = verbose
+    
+    def vprint(self, *args, **kwargs):
+        if self.verbose:
+            print(*args, **kwargs)
 
     def reset(self, datasize):
         if datasize != self.datasize: # re-allocate the buffer only if the datasize changes
@@ -37,7 +42,7 @@ class RAMBufferBase(object):
             buffer_base = mp.Array(self.ctype, datanum)
             self.buffer = np.ctypeslib.as_array(buffer_base.get_obj())
             self.buffer = self.buffer.reshape(self.datasize)
-            print("RAM Buffer allocated size {}, mem {} G".format(datasize, datanum * self.databyte / 1000./1000./1000.))
+            self.vprint("RAM Buffer allocated size {}, mem {} G".format(datasize, datanum * self.databyte / 1000./1000./1000.))
 
     def insert(self, index, data):
         assert data.shape == self.datasize[1:], "Insert data shape error! Data shape {}, buffer shape {}".format(data.shape, self.datasize)

--- a/RAMDataset.py
+++ b/RAMDataset.py
@@ -37,6 +37,7 @@ class RAMDataset(Dataset):
         transform = None, \
         frame_skip = 0, \
         seq_stride = 1, \
+        verbose = False
         ):  
 
         super(RAMDataset, self).__init__()
@@ -72,7 +73,13 @@ class RAMDataset(Dataset):
 
         self.is_epoch_complete = False # flag is set to true after all the data is sampled
 
-        print('Loaded {} sequences from the RAM, which contains {} frames...'.format(self.N, self.framenumFromFile))
+        self.verbose = verbose
+
+        self.vprint('Loaded {} sequences from the RAM, which contains {} frames...'.format(self.N, self.framenumFromFile))
+
+    def vprint(self, *args, **kwargs):
+        if self.verbose:
+            print(*args, **kwargs)
 
     def parse_seqnum(self):
         seqnumlist = []

--- a/TrajBuffer.py
+++ b/TrajBuffer.py
@@ -10,7 +10,7 @@ class TrajBuffer(object):
     mod_datatypes: list of data types
     mod_sizes: list of data sizes
     '''
-    def __init__(self, keylist, modtypelist):
+    def __init__(self, keylist, modtypelist, verbose=False):
         assert len(keylist) == len(modtypelist), "The keylist length {} and modlist length {} don't match".format(len(keylist), len(modtypelist))
         self.mod_names = keylist
         self.modtypelist = modtypelist
@@ -22,7 +22,7 @@ class TrajBuffer(object):
         for modname, modtype in zip(self.mod_names, self.modtypelist):
             self.mod_datatypes.append(modtype.data_type)
             self.mod_sizes.append(modtype.data_shape)
-            self.buffer[modname] = RAMBufferBase(modtype.data_type)
+            self.buffer[modname] = RAMBufferBase(modtype.data_type, verbose = verbose)
             self.full[modname] = False
 
         self.trajlist, self.trajlenlist, self.framelist = [],[],[]

--- a/input_parser.py
+++ b/input_parser.py
@@ -1,3 +1,6 @@
+import os
+
+
 def parse_inputfile(inputfile):
     '''
     trajlist: [TRAJ0, TRAJ1, ...]
@@ -11,6 +14,10 @@ def parse_inputfile(inputfile):
     while ind<len(lines):
         line = lines[ind].strip()
         traj, trajlen = line.split(' ')
+
+        # Break path and rebuild it to avoid problems with Windows and Linux.
+        traj = os.path.join(*traj.split("\\"))
+        
         trajlen = int(trajlen)
         trajlist.append(traj)
         trajlenlist.append(trajlen)

--- a/modality_type/tartanair_types.py
+++ b/modality_type/tartanair_types.py
@@ -458,8 +458,7 @@ class imu_gyro(IMUBase):
 @register(TYPEDICT)
 class pose_lcam_front(SimpleModBase):
     '''
-    This defines modality that is light-weight
-    such as IMU, pose, wheel_encoder
+    The pose of the left front camera.
     '''
     def __init__(self, datashape):
         super().__init__(datashape)
@@ -467,6 +466,172 @@ class pose_lcam_front(SimpleModBase):
 
     def get_filename(self):
         return 'pose_lcam_front.txt'
+
+    def data_padding(self):
+        return None
+
+@register(TYPEDICT)
+class pose_lcam_right(SimpleModBase):
+    '''
+    The pose of the left right-facing camera.
+    '''
+    def __init__(self, datashape):
+        super().__init__(datashape)
+        self.data_shape = (7,)
+
+    def get_filename(self):
+        return 'pose_lcam_right.txt'
+
+    def data_padding(self):
+        return None
+
+@register(TYPEDICT)
+class pose_lcam_back(SimpleModBase):
+    '''
+    The pose of the left back-facing camera.
+    '''
+    def __init__(self, datashape):
+        super().__init__(datashape)
+        self.data_shape = (7,)
+
+    def get_filename(self):
+        return 'pose_lcam_back.txt'
+
+    def data_padding(self):
+        return None
+
+@register(TYPEDICT)
+class pose_lcam_left(SimpleModBase):
+    '''
+    The pose of the left left-facing camera.
+    '''
+    def __init__(self, datashape):
+        super().__init__(datashape)
+        self.data_shape = (7,)
+
+    def get_filename(self):
+        return 'pose_lcam_left.txt'
+
+    def data_padding(self):
+        return None
+
+@register(TYPEDICT)
+class pose_lcam_top(SimpleModBase):
+    '''
+    The pose of the left top-facing camera.
+    '''
+    def __init__(self, datashape):
+        super().__init__(datashape)
+        self.data_shape = (7,)
+
+    def get_filename(self):
+        return 'pose_lcam_top.txt'
+
+    def data_padding(self):
+        return None
+
+@register(TYPEDICT)
+class pose_lcam_bottom(SimpleModBase):
+    '''
+    The pose of the left bottom-facing camera.
+    '''
+    def __init__(self, datashape):
+        super().__init__(datashape)
+        self.data_shape = (7,)
+
+    def get_filename(self):
+        return 'pose_lcam_bottom.txt'
+
+    def data_padding(self):
+        return None
+
+
+@register(TYPEDICT)
+class pose_rcam_front(SimpleModBase):
+    '''
+    The pose of the left front camera.
+    '''
+    def __init__(self, datashape):
+        super().__init__(datashape)
+        self.data_shape = (7,)
+
+    def get_filename(self):
+        return 'pose_rcam_front.txt'
+
+    def data_padding(self):
+        return None
+
+@register(TYPEDICT)
+class pose_rcam_right(SimpleModBase):
+    '''
+    The pose of the left right-facing camera.
+    '''
+    def __init__(self, datashape):
+        super().__init__(datashape)
+        self.data_shape = (7,)
+
+    def get_filename(self):
+        return 'pose_rcam_right.txt'
+
+    def data_padding(self):
+        return None
+
+@register(TYPEDICT)
+class pose_rcam_back(SimpleModBase):
+    '''
+    The pose of the left back-facing camera.
+    '''
+    def __init__(self, datashape):
+        super().__init__(datashape)
+        self.data_shape = (7,)
+
+    def get_filename(self):
+        return 'pose_rcam_back.txt'
+
+    def data_padding(self):
+        return None
+
+@register(TYPEDICT)
+class pose_rcam_left(SimpleModBase):
+    '''
+    The pose of the left left-facing camera.
+    '''
+    def __init__(self, datashape):
+        super().__init__(datashape)
+        self.data_shape = (7,)
+
+    def get_filename(self):
+        return 'pose_rcam_left.txt'
+
+    def data_padding(self):
+        return None
+
+@register(TYPEDICT)
+class pose_rcam_top(SimpleModBase):
+    '''
+    The pose of the left top-facing camera.
+    '''
+    def __init__(self, datashape):
+        super().__init__(datashape)
+        self.data_shape = (7,)
+
+    def get_filename(self):
+        return 'pose_rcam_top.txt'
+
+    def data_padding(self):
+        return None
+
+@register(TYPEDICT)
+class pose_rcam_bottom(SimpleModBase):
+    '''
+    The pose of the left bottom-facing camera.
+    '''
+    def __init__(self, datashape):
+        super().__init__(datashape)
+        self.data_shape = (7,)
+
+    def get_filename(self):
+        return 'pose_rcam_bottom.txt'
 
     def data_padding(self):
         return None


### PR DESCRIPTION
Wenshan, this data cacher is incredible.

This is a minor PR including the following:

1. Syntax migration from Python 2 to Python 3 (minor changes, mostly interaction with iterators).
2. Allowing users to pass configuration dictionaries to MultiDatasets and not only YAML files.
3. Allowing the configuration YAML/dictionaries to include a dataset root path override, so a path file will not be used. I feel like this may not be a good functionality -- we should consider changing this to a better interface.
4. Path structures in the txt files of `analyze` "rebuilt" (deconstructed and constructed again) to account for local convention. 